### PR TITLE
Fix destroy word

### DIFF
--- a/app/controllers/words_controller.rb
+++ b/app/controllers/words_controller.rb
@@ -22,7 +22,7 @@ class WordsController < ApplicationController
   end
 
   def destroy
-    @word = Word.find_by(params[:id])
+    @word = Word.find(params[:id])
     @word.destroy
     flash[:success] = "単語を削除しました"
     redirect_to words_path

--- a/app/views/words/index.html.erb
+++ b/app/views/words/index.html.erb
@@ -9,12 +9,10 @@
       </div>
       <div class="words-index">
         <% @words.each do |word| %>
-          <%= word.id %>.
           <%= word.word %>
           <% if current_user.admin? %>
             <%= link_to "delete", word_path(word), method: :delete, data: {confirm: "You sure?"} %>
-          <% end %>
-          <br>
+          <% end %>　　　
         <% end %>
       </div>
     </div>


### PR DESCRIPTION
選択した単語ではない単語が消されていく問題。 
find_byからfindにすることで解決。